### PR TITLE
Included support for browser-side node-style (commonjs) exports

### DIFF
--- a/lucid.js
+++ b/lucid.js
@@ -14,8 +14,8 @@
 	if(typeof define === 'function' && define.amd) {
 		define(factory);
 
-	//NODE
-	} else if(typeof document === 'undefined' && typeof module === 'object') {
+	//NODE (OR NODE-STYLE MODULES)
+	} else if( typeof module === 'object' && module.exports ) {
 		module.exports = factory();
 
 	//DOM GLOBAL


### PR DESCRIPTION
Having a test for 'document' will automatically exclude users from being able to use commonjs in the browsers.  Let's not let such a fate befall this very nice little lib ^^.
