### PR TITLE
once() doesnt return false

### DIFF
--- a/lucid.js
+++ b/lucid.js
@@ -156,9 +156,11 @@
 
 				for(aI = 0; aI < args.length; aI += 1) {
 					if(args[aI].apply(this, eventArgs) === false) {
-						result = true;
+						result = false;
 					}
 				}
+
+				return result
 			});
 
 			return binding;


### PR DESCRIPTION
Listeners bound with once() doesnt return the false value, as dynamic listener wrapper simply doesnt return anything.
