### PR TITLE
Undefined emitter fix

### DIFF
--- a/lib/event-emitter.js
+++ b/lib/event-emitter.js
@@ -211,8 +211,11 @@ EventEmitter.prototype.emit = function(event    ) {
 
       var eventEmitters = this._eventEmitters[expandedEvent];
       if(!eventEmitters) { continue; }
-      for(var i = 0; i < eventEmitters.length; i += 1) {
+      for(var j = 0; j < eventEmitters.length; j += 1) {
         eventEmitter = eventEmitters[i];
+        if (!eventEmitter) {
+          continue;
+        }
         eventEmitter._remoteSource = this;
         eventEmitter.emit.apply(eventEmitter, arguments);
       }


### PR DESCRIPTION
Updated nested loop counter name duplicate and checking if its defined. Reproduced with a bind using "once". Filtering should be introduced in the proper place and undefined check removed.
